### PR TITLE
Validate Features for Specific Teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ FeatureMap comes with a validation function to ensure the following things are t
 1) Only one mechanism is defining the feature assignment for a file. That is -- you can't have a file annotation on a file assigned via glob-based assignment. This helps make feature assignment behavior more clear by avoiding concerns about precedence.
 2) All features referenced as an assignment for any file is a valid feature (i.e. it's in the list of `CodeFeatures.all`).
 3) All files have a feature assigned. You can specify in `unassigned_globs` to represent a TODO list of files to add feature assignments to.
+  * Teams using the [CodeOwnership](https://github.com/rubyatscale/code_ownership/tree/main) gem include a `require_assignment_for_teams` key in the `feature_map.yml` file to have this validation to apply a specific list of team. This allows feature assignments to be rolled out in a gradual manner on a team-by-team basis. The `require_assignment_for_teams` configuration should contain a list of team names (i.e. the value from the `name` key in the associated `config/teams/*.yml` file) for the teams whose files will be included in this validation.
 3) The `FEATURES.yml` file is up to date. This is automatically corrected and staged unless specified otherwise with `bin/featuremap validate --skip-autocorrect --skip-stage`. You can turn this validation off by setting `skip_features_validation: true` in `config/feature_map.yml`.
 
 FeatureMap also allows you to specify which globs and file extensions should be considered assignable.

--- a/feature_map.gemspec
+++ b/feature_map.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir['README.md', 'lib/**/*', 'bin/**/*']
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'code_ownership'
   spec.add_dependency 'packs-specification'
   spec.add_dependency 'sorbet-runtime', '>= 0.5.11249'
 

--- a/lib/feature_map/configuration.rb
+++ b/lib/feature_map/configuration.rb
@@ -9,6 +9,7 @@ module FeatureMap
     const :unbuilt_gems_path, T.nilable(String)
     const :skip_features_validation, T::Boolean
     const :raw_hash, T::Hash[T.untyped, T.untyped]
+    const :require_assignment_for_teams, T.nilable(T::Array[String])
 
     sig { returns(Configuration) }
     def self.fetch
@@ -24,7 +25,8 @@ module FeatureMap
         assigned_globs: config_hash.fetch('assigned_globs', []),
         unassigned_globs: config_hash.fetch('unassigned_globs', []),
         skip_features_validation: config_hash.fetch('skip_features_validation', false),
-        raw_hash: config_hash
+        raw_hash: config_hash,
+        require_assignment_for_teams: config_hash.fetch('require_assignment_for_teams', nil)
       )
     end
   end

--- a/sorbet/rbi/code_ownership.rbi
+++ b/sorbet/rbi/code_ownership.rbi
@@ -1,0 +1,17 @@
+# typed: true
+
+# Tried generating this file using tapioca but it pulled in a lot of additional dependencies and complexity that
+# caused errors in the Sorbet type check oputput.
+
+# source://code_ownership//lib/code_ownership/mapper.rb#5
+module CodeOwnership
+  requires_ancestor { Kernel }
+
+  class << self
+    # @param file [String]
+    # @return [CodeTeams::Team, nil]
+    #
+    # source://code_ownership//lib/code_ownership.rb#30
+    def for_file(file); end
+  end
+end

--- a/spec/lib/feature_map/private/validations/files_have_features_spec.rb
+++ b/spec/lib/feature_map/private/validations/files_have_features_spec.rb
@@ -31,22 +31,90 @@ module FeatureMap
             write_configuration
           end
 
-          it 'lets the user know the file must have a feature assignment' do
-            expect { FeatureMap.validate! }.to raise_error do |e|
-              expect(e).to be_a FeatureMap::InvalidFeatureMapConfigurationError
-              expect(e.message).to eq <<~EXPECTED.chomp
-                Some files are missing a feature assignment:
+          context 'when no require_assignment_for_teams configuration is set' do
+            it 'lets the user know the file must have a feature assignment' do
+              expect { FeatureMap.validate! }.to raise_error do |e|
+                expect(e).to be_a FeatureMap::InvalidFeatureMapConfigurationError
+                expect(e.message).to eq <<~EXPECTED.chomp
+                  Some files are missing a feature assignment:
 
-                - app/missing_assignment.rb
+                  - app/missing_assignment.rb
 
-                See https://github.com/Beyond-Finance/feature_map#README.md for more details
-              EXPECTED
+                  See https://github.com/Beyond-Finance/feature_map#README.md for more details
+                EXPECTED
+              end
+            end
+
+            context 'the input files do not include the file missing a feature assignment' do
+              it 'ignores the file missing a feature assignment' do
+                expect { FeatureMap.validate!(files: ['app/some_other_file.rb']) }.to_not raise_error
+              end
             end
           end
 
-          context 'the input files do not include the file missing a feature assignment' do
-            it 'ignores the file missing a feature assignment' do
-              expect { FeatureMap.validate!(files: ['app/some_other_file.rb']) }.to_not raise_error
+          context 'when a set of teams is specified in the require_assignment_for_teams configuration' do
+            before do
+              write_file('config/code_ownership.yml', <<~CONTENTS)
+                owned_globs: ['app/**/**']
+              CONTENTS
+
+              # The CodeOwnership gem and its underlying dependencies do a lot of internal caching. The following
+              # operations are required to reset these caches between each test to avoid polluting state across tests.
+              CodeOwnership.bust_caches!
+              CodeTeams.bust_caches!
+
+              write_configuration('unassigned_globs' => ['config/teams/**'], 'require_assignment_for_teams' => ['Assigned Team'])
+            end
+
+            context 'when the file is assigned to a team that IS in the require_assignment_for_teams set' do
+              before do
+                write_file('config/teams/assigned_team.yml', <<~CONTENTS)
+                  name: Assigned Team
+                  github:
+                    team: '@My-Org/assigned-team'
+                  owned_globs: ['app/missing_assignment.rb']
+                CONTENTS
+              end
+
+              it 'lets the user know the file must have a feature assignment' do
+                expect { FeatureMap.validate! }.to raise_error do |e|
+                  expect(e).to be_a FeatureMap::InvalidFeatureMapConfigurationError
+                  expect(e.message).to eq <<~EXPECTED.chomp
+                    Some files are missing a feature assignment:
+
+                    - app/missing_assignment.rb
+
+                    See https://github.com/Beyond-Finance/feature_map#README.md for more details
+                  EXPECTED
+                end
+              end
+
+              context 'the input files do not include the file missing a feature assignment' do
+                it 'ignores the file missing a feature assignment' do
+                  expect { FeatureMap.validate!(files: ['app/some_other_file.rb']) }.to_not raise_error
+                end
+              end
+            end
+
+            context 'when the file is not assigned to any team' do
+              it 'does not raise an error' do
+                expect { FeatureMap.validate! }.to_not raise_error
+              end
+            end
+
+            context 'when the file is assigned to a team that IS NOT in the require_assignment_for_teams set' do
+              before do
+                write_file('config/teams/unassigned_team.yml', <<~CONTENTS)
+                  name: UnAssigned Team
+                  github:
+                    team: '@My-Org/unassigned-team'
+                  owned_globs: ['app/missing_assignment.rb']
+                CONTENTS
+              end
+
+              it 'does not raise an error' do
+                expect { FeatureMap.validate! }.to_not raise_error
+              end
             end
           end
         end


### PR DESCRIPTION
Adds support for configuring specific CodeOwnership teams whose files should be included in the feature assignment validations. This will allow us to roll this functionality out on a team by team basis.