### PR TITLE
adds rounding to `abc_size` metrics

### DIFF
--- a/lib/feature_map/private/feature_metrics_calculator.rb
+++ b/lib/feature_map/private/feature_metrics_calculator.rb
@@ -59,7 +59,7 @@ module FeatureMap
         cyclomatic_calculator = CyclomaticComplexityCalculator.new(source.ast)
 
         {
-          ABC_SIZE_METRIC => abc_calculator.calculate.first,
+          ABC_SIZE_METRIC => abc_calculator.calculate.first.round(2),
           CYCLOMATIC_COMPLEXITY_METRIC => cyclomatic_calculator.calculate,
           LINES_OF_CODE_METRIC => code_length_calculator.calculate
         }


### PR DESCRIPTION
Rounds `abc_size` metric to 2 decimals to prevent this...

![image](https://github.com/user-attachments/assets/2a036cca-751d-41af-9a2b-e632ecf12ab1)
