### PR TITLE
Lines of Code Calculator

### DIFF
--- a/lib/feature_map/private.rb
+++ b/lib/feature_map/private.rb
@@ -4,6 +4,7 @@
 
 require 'feature_map/private/extension_loader'
 require 'feature_map/private/cyclomatic_complexity_calculator'
+require 'feature_map/private/lines_of_code_calculator'
 require 'feature_map/private/feature_metrics_calculator'
 require 'feature_map/private/assignments_file'
 require 'feature_map/private/metrics_file'

--- a/lib/feature_map/private/cyclomatic_complexity_calculator.rb
+++ b/lib/feature_map/private/cyclomatic_complexity_calculator.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 require 'parser/current'
-require 'sorbet-runtime'
 
 module FeatureMap
   module Private

--- a/lib/feature_map/private/feature_metrics_calculator.rb
+++ b/lib/feature_map/private/feature_metrics_calculator.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 require 'rubocop'
-require 'sorbet-runtime'
 
 module FeatureMap
   module Private
@@ -48,20 +47,14 @@ module FeatureMap
         # which does introduce some risk, should RuboCop decide to change the interface
         # of these classes. That being said, this is a tradeoff we're willing to
         # make right now.
-        code_length_calculator = RuboCop::Cop::Metrics::Utils::CodeLengthCalculator.new(
-          source.ast,
-          source,
-          count_comments: false,
-          foldable_types: %i[array hash heredoc method_call]
-        )
-
+        lines_of_code_calculator = LinesOfCodeCalculator.new(file_path)
         abc_calculator = RuboCop::Cop::Metrics::Utils::AbcSizeCalculator.new(source.ast)
         cyclomatic_calculator = CyclomaticComplexityCalculator.new(source.ast)
 
         {
           ABC_SIZE_METRIC => abc_calculator.calculate.first.round(2),
           CYCLOMATIC_COMPLEXITY_METRIC => cyclomatic_calculator.calculate,
-          LINES_OF_CODE_METRIC => code_length_calculator.calculate
+          LINES_OF_CODE_METRIC => lines_of_code_calculator.calculate
         }
       end
     end

--- a/lib/feature_map/private/lines_of_code_calculator.rb
+++ b/lib/feature_map/private/lines_of_code_calculator.rb
@@ -1,0 +1,23 @@
+# typed: strict
+# frozen_string_literal: true
+
+require 'parser/current'
+
+module FeatureMap
+  module Private
+    class LinesOfCodeCalculator
+      extend T::Sig
+
+      sig { params(file_path: String).void }
+      def initialize(file_path)
+        @file_path = file_path
+      end
+
+      sig { returns(Integer) }
+      def calculate
+        # Ignore lines that are entirely whitespace or that are entirely a comment.
+        File.readlines(@file_path).grep_v(/\A\s*(#.*)?\Z/i).length
+      end
+    end
+  end
+end

--- a/lib/feature_map/private/metrics_file.rb
+++ b/lib/feature_map/private/metrics_file.rb
@@ -71,7 +71,8 @@ module FeatureMap
         cache.each_value do |assignment_map_cache|
           assignment_map_cache.to_h.each do |path, feature|
             feature_files[feature.name] ||= T.let([], FileList)
-            T.must(feature_files[feature.name]) << path
+            files = Dir.glob(path).reject { |glob_entry| File.directory?(glob_entry) }
+            files.each { |file| T.must(feature_files[feature.name]) << file }
           end
         end
 

--- a/spec/lib/feature_map/private/cyclomatic_complexity_calculator_spec.rb
+++ b/spec/lib/feature_map/private/cyclomatic_complexity_calculator_spec.rb
@@ -4,48 +4,46 @@
 require 'spec_helper'
 
 module FeatureMap
-  module Private
-    RSpec.describe CyclomaticComplexityCalculator do
-      describe '#calculate' do
-        it 'returns 1 for an empty method' do
-          code = 'def empty_method; end'
-          source = RuboCop::ProcessedSource.new(code, RUBY_VERSION.to_f)
-          calculator = described_class.new(source.ast)
+  RSpec.describe Private::CyclomaticComplexityCalculator do
+    describe '#calculate' do
+      it 'returns 1 for an empty method' do
+        code = 'def empty_method; end'
+        source = RuboCop::ProcessedSource.new(code, RUBY_VERSION.to_f)
+        calculator = described_class.new(source.ast)
 
-          expect(calculator.calculate).to eq(1)
-        end
+        expect(calculator.calculate).to eq(1)
+      end
 
-        it 'counts if statements' do
-          code = <<~RUBY
-            def complex_method
-              if condition1
-                do_something
-              elsif condition2
-                do_something_else
-              end
+      it 'counts if statements' do
+        code = <<~RUBY
+          def complex_method
+            if condition1
+              do_something
+            elsif condition2
+              do_something_else
             end
-          RUBY
+          end
+        RUBY
 
-          source = RuboCop::ProcessedSource.new(code, RUBY_VERSION.to_f)
-          calculator = described_class.new(source.ast)
+        source = RuboCop::ProcessedSource.new(code, RUBY_VERSION.to_f)
+        calculator = described_class.new(source.ast)
 
-          expect(calculator.calculate).to eq(3) # Base 1 + 2 conditions
-        end
+        expect(calculator.calculate).to eq(3) # Base 1 + 2 conditions
+      end
 
-        it 'counts logical operators' do
-          code = <<~RUBY
-            def complex_method
-              if condition1 && condition2 || condition3
-                do_something
-              end
+      it 'counts logical operators' do
+        code = <<~RUBY
+          def complex_method
+            if condition1 && condition2 || condition3
+              do_something
             end
-          RUBY
+          end
+        RUBY
 
-          source = RuboCop::ProcessedSource.new(code, RUBY_VERSION.to_f)
-          calculator = described_class.new(source.ast)
+        source = RuboCop::ProcessedSource.new(code, RUBY_VERSION.to_f)
+        calculator = described_class.new(source.ast)
 
-          expect(calculator.calculate).to eq(4) # Base 1 + if + and + or
-        end
+        expect(calculator.calculate).to eq(4) # Base 1 + if + and + or
       end
     end
   end

--- a/spec/lib/feature_map/private/feature_metrics_calculator_spec.rb
+++ b/spec/lib/feature_map/private/feature_metrics_calculator_spec.rb
@@ -21,7 +21,7 @@ module FeatureMap
           expect(metrics['abc_size']).to be_kind_of(Numeric)
           expect(metrics['abc_size']).to be > 0
           expect(metrics['lines_of_code']).to be_kind_of(Integer)
-          expect(metrics['lines_of_code']).to eq(5) # Accounts for the actual lines in the file
+          expect(metrics['lines_of_code']).to eq(5) # Counts all non-whitespace, non-comment lines
         end
       end
 
@@ -56,7 +56,7 @@ module FeatureMap
           expect(metrics['abc_size']).to be_kind_of(Numeric)
           expect(metrics['abc_size']).to be > 2 # Should be more complex than simple file
           expect(metrics['lines_of_code']).to be_kind_of(Integer)
-          expect(metrics['lines_of_code']).to eq(19) # Accounts for the actual lines in the file
+          expect(metrics['lines_of_code']).to eq(16) # Counts all non-whitespace, non-comment lines
         end
       end
     end
@@ -168,19 +168,19 @@ module FeatureMap
 
           expect(simple_feature).to eq({
                                          'abc_size' => 1.41,
-                                         'lines_of_code' => 5,
+                                         'lines_of_code' => 4,
                                          'cyclomatic_complexity' => 1
                                        })
 
           expect(moderate_feature).to eq({
                                            'abc_size' => 9.6,
-                                           'lines_of_code' => 16,
+                                           'lines_of_code' => 15,
                                            'cyclomatic_complexity' => 3
                                          })
 
           expect(complex_feature).to eq({
                                           'abc_size' => 26.83,
-                                          'lines_of_code' => 37,
+                                          'lines_of_code' => 35,
                                           'cyclomatic_complexity' => 7
                                         })
         end

--- a/spec/lib/feature_map/private/lines_of_code_calculator_spec.rb
+++ b/spec/lib/feature_map/private/lines_of_code_calculator_spec.rb
@@ -1,0 +1,94 @@
+# typed: false
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module FeatureMap
+  RSpec.describe Private::LinesOfCodeCalculator do
+    let(:calculator) { described_class.new(file_path) }
+    let(:file_path) { 'app/lines_of_code_test.rb' }
+
+    describe '#calculate' do
+      it 'returns 0 for a file with only comments and whitespace' do
+        # rubocop:disable Layout/TrailingWhitespace
+        write_file(file_path, <<~CONTENTS)
+          # Test 123
+            
+          \t 
+            
+        CONTENTS
+        # rubocop:enable Layout/TrailingWhitespace
+
+        expect(calculator.calculate).to eq(0)
+      end
+
+      it 'includes module, class, and method defitions in the count' do
+        write_file(file_path, <<~CONTENTS)
+          module FeatureMap
+            class LinesOfCodeTest
+              def self.a_method; end
+            end
+          end
+        CONTENTS
+
+        expect(calculator.calculate).to eq(5)
+      end
+
+      it 'includes constants and each line of array/hash defitions in the count' do
+        write_file(file_path, <<~CONTENTS)
+          class LinesOfCodeTest
+            SOME_CONSTANT_ARRAY = [
+              1,
+              2,
+              3
+            ].freeze
+
+            ANOTHER_CONSTANT_HASH = {
+              a: 1,
+              b: 2,
+              c: 3
+            }.freeze
+          end
+        CONTENTS
+
+        expect(calculator.calculate).to eq(12)
+      end
+
+      it 'includes all other source code lines in the count' do
+        write_file(file_path, <<~CONTENTS)
+          class LinesOfCodeTest
+            attr_reader :number
+
+            def initialize(number)
+              @number = number
+            end
+
+            def add_one
+              increment(1)
+            end
+
+            def subtract_two
+              increment(-2)
+            end
+
+            def multiply_by_three
+              multiply(3)
+            end
+
+            private
+
+            def increment(count)
+              @number += count
+            end
+
+            def multiply(multiple)
+              @number *= multiple
+            end
+          end
+        CONTENTS
+
+        expect(calculator.calculate).to eq(22)
+      end
+    end
+  end
+end

--- a/spec/lib/feature_map/private/metrics_file_spec.rb
+++ b/spec/lib/feature_map/private/metrics_file_spec.rb
@@ -17,7 +17,7 @@ module FeatureMap
           features:
             Bar:
               abc_size: 1.0
-              lines_of_code: 3
+              lines_of_code: 5
               cyclomatic_complexity: 1
             Foo:
               abc_size: 2.0


### PR DESCRIPTION
Adds a custom lines of code calculator to ensure all relevant source code lines are counted.

It turns out that the `RuboCop::Cop::Metrics::Utils::CodeLengthCalculator` ignores any code nested within modules/classes inside a parent module/class.

<img width="1512" alt="Screenshot 2024-11-26 at 10 05 13 AM" src="https://github.com/user-attachments/assets/f61a1b6b-ae96-4e64-941b-b1e09c5bcd82">


<details>
    <summary>Test Script</summary>

    code = <<~SOURCE
      module Child
        attr_reader :number
        
        def initialize(number)
            @number = number
        end
        
        def add_one
            increment(1)
        end
        
        def subtract_two
            increment(-2)
        end
        
        def multiply_by_three
            multiply(3)
        end
        
        private
        
        def increment(count)
            @number += count
        end
        
        def multiply(multiple)
            @number *= multiple
        end
      end
    SOURCE
    
    source = RuboCop::ProcessedSource.new(code, RUBY_VERSION.to_f)
    code_length_calculator = RuboCop::Cop::Metrics::Utils::CodeLengthCalculator.new(source.ast, source, count_comments: false, foldable_types: %i[array hash heredoc method_call])
    code_length_calculator.calculate
    
    
    
    nested_source = RuboCop::ProcessedSource.new("module Parent\n#{code}\nend", RUBY_VERSION.to_f)
    nested_code_length_calculator = RuboCop::Cop::Metrics::Utils::CodeLengthCalculator.new(nested_source.ast, nested_source, count_comments: false, foldable_types: %i[array hash heredoc method_call])
    nested_code_length_calculator.calculate
</details>


This is because RuboCop processes the AST recursively evaluating classes, modules, and methods throughout the AST for compliance with the configured ruleset. However we only want to processes files as a whole, so it would be unnecessarily complex to reimplement this same traversal logic. Instead it is simpler to implement our own simplified line counting algorithm.