### PR TITLE
Allow codecov api token to be specified via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Test coverage statistics can be pulled for a specific commit (e.g. the latest co
 
 ### CodeCov API Token Generation
 
-Running the `bin/featuremap test_coverage` will prompt the user to provide an active CodeCov API access token unless one has been specified as the `FEATURE_MAP_CODE_COV_API_KEY` environment variable in your shell's environment. This token is used to retrieve coverage statistics from the CodeCov account configured in the `.feature_map/config.yml` file.
+Running the `bin/featuremap test_coverage` will prompt the user to provide an active CodeCov API access token unless one has been specified as the `CODECOV_TOKEN` environment variable in your shell's environment. This token is used to retrieve coverage statistics from the CodeCov account configured in the `.feature_map/config.yml` file.
 
 Use the following steps to generate a new CodeCov API token:
 
@@ -179,13 +179,13 @@ Use the following steps to generate a new CodeCov API token:
 #### __OPTIONAL__:  Store the token as an environment variable in your shell's environment:
 **ZSH**
   ```shell
-  echo 'export FEATURE_MAP_CODE_COV_API_KEY="YOUR_CODECOV_TOKEN"' >> ~/.zshrc
+  echo 'export CODECOV_TOKEN="YOUR_CODECOV_TOKEN"' >> ~/.zshrc
   ```
 
 **Bash**
   ```shell
   # Bash
-  echo 'export FEATURE_MAP_CODE_COV_API_KEY="YOUR_CODECOV_TOKEN"' >> ~/.bashrc
+  echo 'export CODECOV_TOKEN="YOUR_CODECOV_TOKEN"' >> ~/.bashrc
   ```
 
 ## Proper Configuration & Validation

--- a/lib/feature_map/cli.rb
+++ b/lib/feature_map/cli.rb
@@ -113,7 +113,7 @@ module FeatureMap
       parser = OptionParser.new do |opts|
         opts.banner = <<~MSG
           Usage: bin/featuremap test_coverage [options] [code_cov_commit_sha].
-          Note:  Requires environment variable `FEATURE_MAP_CODE_COV_API_KEY`.
+          Note:  Requires environment variable `CODECOV_TOKEN`.
         MSG
 
         opts.on('--help', 'Shows this prompt') do
@@ -126,8 +126,8 @@ module FeatureMap
       non_flag_args = argv.reject { |arg| arg.start_with?('--') }
       custom_commit_sha = non_flag_args[0]
 
-      code_cov_token = ENV.fetch('FEATURE_MAP_CODE_COV_API_KEY', '')
-      raise 'Please specify a CodeCov API token in your environment as `FEATURE_MAP_CODE_COV_API_KEY`' if code_cov_token.empty?
+      code_cov_token = ENV.fetch('CODECOV_TOKEN', '')
+      raise 'Please specify a CodeCov API token in your environment as `CODECOV_TOKEN`' if code_cov_token.empty?
 
       # If no commit SHA was providid in the CLI command args, use the most recent commit of the main branch in the upstream remote.
       commit_sha = custom_commit_sha || `git log -1 --format=%H origin/main`.chomp

--- a/spec/lib/feature_map/cli_spec.rb
+++ b/spec/lib/feature_map/cli_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe FeatureMap::Cli do
       create_non_empty_application
       create_validation_artifacts
       allow(FeatureMap::Cli).to receive(:`).with('git log -1 --format=%H origin/main').and_return(latest_main_commit)
-      stub_const('ENV', ENV.to_h.merge('FEATURE_MAP_CODE_COV_API_KEY' => code_cov_api_token))
+      stub_const('ENV', ENV.to_h.merge('CODECOV_TOKEN' => code_cov_api_token))
     end
 
     context 'when git sha is provided' do
@@ -102,13 +102,13 @@ RSpec.describe FeatureMap::Cli do
 
     context 'when no codecov api token can be found' do
       before do
-        stub_const('ENV', ENV.to_h.merge('FEATURE_MAP_CODE_COV_API_KEY' => ''))
+        stub_const('ENV', ENV.to_h.merge('CODECOV_TOKEN' => ''))
       end
 
       it 'raises an exception' do
         expect do
           subject
-        end.to raise_error(/Please specify a CodeCov API token in your environment as `FEATURE_MAP_CODE_COV_API_KEY`/)
+        end.to raise_error(/Please specify a CodeCov API token in your environment as `CODECOV_TOKEN`/)
       end
     end
   end


### PR DESCRIPTION
Allows codecov api key to be specified in your shell's environment as the `CODECOV_TOKEN ` var.  Updates corresponding tests and documentation.

![CleanShot 2024-12-18 at 14 57 34](https://github.com/user-attachments/assets/dcde76cb-53e5-4cf8-b356-419122796870)
