### PR TITLE
Update codecov api token environment variable to distinguish from upl…

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Test coverage statistics can be pulled for a specific commit (e.g. the latest co
 
 ### CodeCov API Token Generation
 
-Running the `bin/featuremap test_coverage` will prompt the user to provide an active CodeCov API access token unless one has been specified as the `CODECOV_TOKEN` environment variable in your shell's environment. This token is used to retrieve coverage statistics from the CodeCov account configured in the `.feature_map/config.yml` file.
+Running the `bin/featuremap test_coverage` will prompt the user to provide an active CodeCov API access token unless one has been specified as the `CODECOV_API_TOKEN` environment variable in your shell's environment. This token is used to retrieve coverage statistics from the CodeCov account configured in the `.feature_map/config.yml` file.
 
 Use the following steps to generate a new CodeCov API token:
 
@@ -179,13 +179,13 @@ Use the following steps to generate a new CodeCov API token:
 #### __OPTIONAL__:  Store the token as an environment variable in your shell's environment:
 **ZSH**
   ```shell
-  echo 'export CODECOV_TOKEN="YOUR_CODECOV_TOKEN"' >> ~/.zshrc
+  echo 'export CODECOV_API_TOKEN="YOUR_CODECOV_API_TOKEN"' >> ~/.zshrc
   ```
 
 **Bash**
   ```shell
   # Bash
-  echo 'export CODECOV_TOKEN="YOUR_CODECOV_TOKEN"' >> ~/.bashrc
+  echo 'export CODECOV_API_TOKEN="YOUR_CODECOV_API_TOKEN"' >> ~/.bashrc
   ```
 
 ## Proper Configuration & Validation

--- a/lib/feature_map/cli.rb
+++ b/lib/feature_map/cli.rb
@@ -113,7 +113,7 @@ module FeatureMap
       parser = OptionParser.new do |opts|
         opts.banner = <<~MSG
           Usage: bin/featuremap test_coverage [options] [code_cov_commit_sha].
-          Note:  Requires environment variable `CODECOV_TOKEN`.
+          Note:  Requires environment variable `CODECOV_API_TOKEN`.
         MSG
 
         opts.on('--help', 'Shows this prompt') do
@@ -126,8 +126,8 @@ module FeatureMap
       non_flag_args = argv.reject { |arg| arg.start_with?('--') }
       custom_commit_sha = non_flag_args[0]
 
-      code_cov_token = ENV.fetch('CODECOV_TOKEN', '')
-      raise 'Please specify a CodeCov API token in your environment as `CODECOV_TOKEN`' if code_cov_token.empty?
+      code_cov_token = ENV.fetch('CODECOV_API_TOKEN', '')
+      raise 'Please specify a CodeCov API token in your environment as `CODECOV_API_TOKEN`' if code_cov_token.empty?
 
       # If no commit SHA was providid in the CLI command args, use the most recent commit of the main branch in the upstream remote.
       commit_sha = custom_commit_sha || `git log -1 --format=%H origin/main`.chomp

--- a/spec/lib/feature_map/cli_spec.rb
+++ b/spec/lib/feature_map/cli_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe FeatureMap::Cli do
       create_non_empty_application
       create_validation_artifacts
       allow(FeatureMap::Cli).to receive(:`).with('git log -1 --format=%H origin/main').and_return(latest_main_commit)
-      stub_const('ENV', ENV.to_h.merge('CODECOV_TOKEN' => code_cov_api_token))
+      stub_const('ENV', ENV.to_h.merge('CODECOV_API_TOKEN' => code_cov_api_token))
     end
 
     context 'when git sha is provided' do
@@ -102,13 +102,13 @@ RSpec.describe FeatureMap::Cli do
 
     context 'when no codecov api token can be found' do
       before do
-        stub_const('ENV', ENV.to_h.merge('CODECOV_TOKEN' => ''))
+        stub_const('ENV', ENV.to_h.merge('CODECOV_API_TOKEN' => ''))
       end
 
       it 'raises an exception' do
         expect do
           subject
-        end.to raise_error(/Please specify a CodeCov API token in your environment as `CODECOV_TOKEN`/)
+        end.to raise_error(/Please specify a CodeCov API token in your environment as `CODECOV_API_TOKEN`/)
       end
     end
   end


### PR DESCRIPTION
…oad token

The `CODECOV_TOKEN` in our CI environment references an "upload" token which is used only to upload coverage reports.  We separately need the ability to configure an environment variable for an API token in order to _retrieve_ coverage.