### PR TITLE
Add script to apply feature assignments

### DIFF
--- a/lib/feature_map.rb
+++ b/lib/feature_map.rb
@@ -22,6 +22,11 @@ module FeatureMap
   requires_ancestor { Kernel }
   GlobsToAssignedFeatureMap = T.type_alias { T::Hash[String, CodeFeatures::Feature] }
 
+  sig { params(assignments_file_path: String).void }
+  def apply_assignments!(assignments_file_path)
+    Private.apply_assignments!(assignments_file_path)
+  end
+
   sig { params(file: String).returns(T.nilable(CodeFeatures::Feature)) }
   def for_file(file)
     @for_file ||= T.let(@for_file, T.nilable(T::Hash[String, T.nilable(CodeFeatures::Feature)]))

--- a/lib/feature_map/cli.rb
+++ b/lib/feature_map/cli.rb
@@ -9,7 +9,9 @@ module FeatureMap
   class Cli
     def self.run!(argv)
       command = argv.shift
-      if command == 'validate'
+      if command == 'apply_assignments'
+        apply_assignments!(argv)
+      elsif command == 'validate'
         validate!(argv)
       elsif command == 'docs'
         docs!(argv)
@@ -26,17 +28,45 @@ module FeatureMap
           Usage: bin/featuremap <subcommand>
 
           Subcommands:
-            validate - run all validations
+            apply_assignments - applies specified feature assignments to source files
             docs - generates feature documentation
+            for_feature - find assignment information for a feature
+            for_file - find feature assignment for a single file
             test_coverage - generates per-feature test coverage statistics
             test_pyramid - generates per-feature test pyramid (unit, integration, regression) statistics
-            for_file - find feature assignment for a single file
-            for_feature - find assignment information for a feature
+            validate - run all validations
+
+            ##################################################
             help  - display help information about feature_map
+            ##################################################
         USAGE
       else
         puts "'#{command}' is not a feature_map command. See `bin/featuremap help`."
       end
+    end
+
+    def self.apply_assignments!(argv)
+      parser = OptionParser.new do |opts|
+        opts.banner = <<~MSG
+          Usage: bin/featuremap apply_assignments [assignments.csv].
+          Note:  Expects two fields with no header:  dir/filepath,feature
+                 Supports assignments in the following filetypes:
+                   cls,html,js,jsx,rb,ts,tsx,xml
+        MSG
+
+        opts.on('--help', 'Shows this prompt') do
+          puts opts
+          exit
+        end
+      end
+      args = parser.order!(argv)
+      parser.parse!(args)
+      non_flag_args = argv.reject { |arg| arg.start_with?('--') }
+      assignments_file_path = non_flag_args[0]
+
+      raise 'Please specify assignments.csv file' if assignments_file_path.nil?
+
+      FeatureMap.apply_assignments!(assignments_file_path)
     end
 
     def self.validate!(argv)

--- a/lib/feature_map/private.rb
+++ b/lib/feature_map/private.rb
@@ -2,6 +2,8 @@
 
 # typed: strict
 
+require 'csv'
+
 require 'feature_map/constants'
 require 'feature_map/private/extension_loader'
 require 'feature_map/private/cyclomatic_complexity_calculator'
@@ -9,6 +11,7 @@ require 'feature_map/private/lines_of_code_calculator'
 require 'feature_map/private/todo_inspector'
 require 'feature_map/private/feature_metrics_calculator'
 require 'feature_map/private/assignments_file'
+require 'feature_map/private/assignment_applicator'
 require 'feature_map/private/metrics_file'
 require 'feature_map/private/glob_cache'
 require 'feature_map/private/feature_assigner'
@@ -36,6 +39,12 @@ module FeatureMap
         FeatureName,
         FileList
       ]
+    end
+
+    sig { params(assignments_file_path: String).void }
+    def self.apply_assignments!(assignments_file_path)
+      assignments = CSV.read(assignments_file_path)
+      AssignmentApplicator.apply_assignments!(assignments)
     end
 
     sig { returns(Configuration) }

--- a/lib/feature_map/private/assignment_applicator.rb
+++ b/lib/feature_map/private/assignment_applicator.rb
@@ -1,0 +1,112 @@
+# typed: strict
+# frozen_string_literal: true
+
+module FeatureMap
+  module Private
+    class AssignmentApplicator
+      extend T::Sig
+
+      sig { params(assignments: T::Array[T::Array[T.nilable(String)]]).void }
+      def self.apply_assignments!(assignments)
+        file_to_feature_map = map_files_to_feature
+        assignments.each do |(filepath, feature)|
+          next puts("Missing data: #{filepath}, #{feature}") unless filepath && feature
+          next puts("Already assigned: #{filepath}, #{feature}") if file_to_feature_map[filepath]
+
+          apply_assignment(filepath, feature)
+        end
+      end
+
+      sig { params(filepath: String, feature: String).void }
+      def self.apply_assignment(filepath, feature)
+        return apply_to_directory(filepath, feature) if File.directory?(filepath)
+
+        # NOTE:  For simplicity we're reading the entire file into system memory
+        #        and then writing it back out.  This breaks in theory for exceptionally
+        #        large source files on very resource-constrained machines.  In practice it's
+        #        probably fine.
+        file = File.readlines(filepath)
+        case File.extname(filepath)
+        when '.cls'
+          apply_to_apex(file, filepath, feature)
+        when '.html'
+          apply_to_html(file, filepath, feature)
+        when '.js', '.jsx', '.ts', '.tsx'
+          apply_to_javascript(file, filepath, feature)
+        when '.rb'
+          apply_to_ruby(file, filepath, feature)
+        when '.xml'
+          apply_to_xml(file, filepath, feature)
+        else
+          puts "Cannot auto assign #{filepath} to #{feature}"
+        end
+      end
+
+      sig { params(file: T::Array[String], filepath: String, feature: String).void }
+      def self.apply_to_apex(file, filepath, feature)
+        File.open(filepath, 'w') do |f|
+          f.write("// @feature #{feature}\n\n")
+          file.each { |line| f.write(line) }
+        end
+      end
+
+      sig { params(filepath: String, feature: String).void }
+      def self.apply_to_directory(filepath, feature)
+        feature_path = File.join(filepath, '.feature')
+
+        File.write(feature_path, "#{feature}\n")
+      end
+
+      sig { params(file: T::Array[String], filepath: String, feature: String).void }
+      def self.apply_to_html(file, filepath, feature)
+        File.open(filepath, 'w') do |f|
+          f.write("<!-- @feature #{feature} -->\n\n")
+          file.each { |line| f.write(line) }
+        end
+      end
+
+      sig { params(file: T::Array[String], filepath: String, feature: String).void }
+      def self.apply_to_javascript(file, filepath, feature)
+        File.open(filepath, 'w') do |f|
+          f.write("// @feature #{feature}\n\n")
+          file.each { |line| f.write(line) }
+        end
+      end
+
+      sig { params(file: T::Array[String], filepath: String, feature: String).void }
+      def self.apply_to_ruby(file, filepath, feature)
+        File.open(filepath, 'w') do |f|
+          # NOTE:  No spacing newline; doing so would separate
+          #        the feature declaration into the only "first" comment
+          #        section, which breaks existing magic comments.
+          #        https://docs.ruby-lang.org/en/3.1/syntax/comments_rdoc.html#label-Magic+Comments
+
+          f.write("# @feature #{feature}\n")
+          file.each { |line| f.write(line) }
+        end
+      end
+
+      sig { params(file: T::Array[String], filepath: String, feature: String).void }
+      def self.apply_to_xml(file, filepath, feature)
+        # NOTE:  Installation of top-level comments in some XML files (notably, in Salesforce)
+        #        breaks parsing.  Instead, we'll insert them right after the opening XML declaration.
+        xml_declaration = file.index { |line| line =~ /<\?xml/i }
+        insert_index = xml_declaration.nil? ? 0 : xml_declaration + 1
+        file.insert(insert_index, "<!-- @feature #{feature} -->\n\n")
+
+        File.open(filepath, 'w') do |f|
+          file.each { |line| f.write(line) }
+        end
+      end
+
+      sig { returns(T::Hash[String, String]) }
+      def self.map_files_to_feature
+        Private.feature_file_assignments.reduce({}) do |content, (feature_name, files)|
+          mapped_files = files.to_h { |f| [f, feature_name] }
+
+          content.merge(mapped_files)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/feature_map/cli_spec.rb
+++ b/spec/lib/feature_map/cli_spec.rb
@@ -40,6 +40,30 @@ RSpec.describe FeatureMap::Cli do
     end
   end
 
+  describe 'apply_assignments' do
+    let(:argv) { ['apply_assignments', 'tmp/assignments.csv'] }
+
+    before do
+      create_non_empty_application
+      create_validation_artifacts
+    end
+
+    it 'uses the provided paths' do
+      expect(FeatureMap).to receive(:apply_assignments!).with('tmp/assignments.csv')
+      subject
+    end
+
+    context 'when missing a file path' do
+      let(:argv) { ['apply_assignments'] }
+
+      it 'raises' do
+        expect do
+          subject
+        end.to raise_error('Please specify assignments.csv file')
+      end
+    end
+  end
+
   describe 'docs' do
     let(:argv) { ['docs'] }
     let(:assigned_globs) { nil }
@@ -228,13 +252,17 @@ RSpec.describe FeatureMap::Cli do
         Usage: bin/featuremap <subcommand>
 
         Subcommands:
-          validate - run all validations
+          apply_assignments - applies specified feature assignments to source files
           docs - generates feature documentation
+          for_feature - find assignment information for a feature
+          for_file - find feature assignment for a single file
           test_coverage - generates per-feature test coverage statistics
           test_pyramid - generates per-feature test pyramid (unit, integration, regression) statistics
-          for_file - find feature assignment for a single file
-          for_feature - find assignment information for a feature
+          validate - run all validations
+
+          ##################################################
           help  - display help information about feature_map
+          ##################################################
       EXPECTED
       expect(FeatureMap::Cli).to receive(:puts).with(expected)
       subject

--- a/spec/lib/feature_map/private/assignment_applicator_spec.rb
+++ b/spec/lib/feature_map/private/assignment_applicator_spec.rb
@@ -1,0 +1,355 @@
+# typed: false
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module FeatureMap
+  RSpec.describe Private::AssignmentApplicator do
+    before do
+      # Must use the skip_features_validation to avoid having the GlobCache loaded from the stub assignments.yml file.
+      write_configuration('skip_features_validation' => true)
+      create_files_with_defined_classes
+    end
+
+    describe '.apply_assignments!' do
+      context 'when assigning to a directory' do
+        it 'injects .feature file into an empty directory' do
+          Dir.mktmpdir('assignment_test') do |dir|
+            feature_path = File.join(dir, '.feature')
+            expect(File.exist?(feature_path)).to eq(false)
+
+            assignments = [[dir.to_s, 'Foo']]
+            described_class.apply_assignments!(assignments)
+
+            expect(File.read(feature_path)).to eq("Foo\n")
+          end
+        end
+
+        it 'overwrites an existing .feature file' do
+          Dir.mktmpdir('assignment_test') do |dir|
+            feature_path = File.join(dir, '.feature')
+            write_file(feature_path, "Bar\n")
+
+            assignments = [[dir.to_s, 'Foo']]
+            described_class.apply_assignments!(assignments)
+
+            expect(File.read(feature_path)).to eq("Foo\n")
+          end
+        end
+      end
+
+      context 'when assigning into a .cls file' do
+        it 'places feature assignment at the top of the file' do
+          write_file('app/test.cls', <<~CONTENTS)
+            global class HelloWorld {
+              public String hello() {
+                return 'Hello World!';
+              }
+            }
+          CONTENTS
+
+          described_class.apply_assignments!([['app/test.cls', 'Foo']])
+
+          expect(File.read('app/test.cls')).to eq(<<~CONTENTS)
+            // @feature Foo
+
+            global class HelloWorld {
+              public String hello() {
+                return 'Hello World!';
+              }
+            }
+          CONTENTS
+        end
+
+        it 'ignores files that already have an assignment' do
+          write_file('app/test.cls', <<~CONTENTS)
+            // @feature Bar
+
+            global class HelloWorld {
+              public String hello() {
+                return 'Hello World!';
+              }
+            }
+          CONTENTS
+
+          expect do
+            described_class.apply_assignments!([['app/test.cls', 'Foo']])
+          end.to output("Already assigned: app/test.cls, Foo\n").to_stdout
+
+          expect(File.read('app/test.cls')).to eq(<<~CONTENTS)
+            // @feature Bar
+
+            global class HelloWorld {
+              public String hello() {
+                return 'Hello World!';
+              }
+            }
+          CONTENTS
+        end
+      end
+
+      context 'when assigning into a .html file' do
+        it 'places feature assignment at the top of the file' do
+          write_file('app/test.html', <<~CONTENTS)
+            <!DOCTYPE html>
+            <html>
+                <head>
+                    <title>Example</title>
+                </head>
+                <body>
+                    <p>This is an example of a simple HTML page with one paragraph.</p>
+                </body>
+            </html>
+          CONTENTS
+
+          described_class.apply_assignments!([['app/test.html', 'Foo']])
+
+          expect(File.read('app/test.html')).to eq(<<~CONTENTS)
+            <!-- @feature Foo -->
+
+            <!DOCTYPE html>
+            <html>
+                <head>
+                    <title>Example</title>
+                </head>
+                <body>
+                    <p>This is an example of a simple HTML page with one paragraph.</p>
+                </body>
+            </html>
+          CONTENTS
+        end
+
+        it 'ignores files that already have an assignment' do
+          write_file('app/test.html', <<~CONTENTS)
+            <!-- @feature Bar -->
+
+            <!DOCTYPE html>
+            <html>
+                <head>
+                    <title>Example</title>
+                </head>
+                <body>
+                    <p>This is an example of a simple HTML page with one paragraph.</p>
+                </body>
+            </html>
+          CONTENTS
+
+          expect do
+            described_class.apply_assignments!([['app/test.html', 'Foo']])
+          end.to output("Already assigned: app/test.html, Foo\n").to_stdout
+
+          expect(File.read('app/test.html')).to eq(<<~CONTENTS)
+            <!-- @feature Bar -->
+
+            <!DOCTYPE html>
+            <html>
+                <head>
+                    <title>Example</title>
+                </head>
+                <body>
+                    <p>This is an example of a simple HTML page with one paragraph.</p>
+                </body>
+            </html>
+          CONTENTS
+        end
+      end
+
+      %w[js jsx ts tsx].each do |jslike_filetype|
+        context "when assigning into a .#{jslike_filetype} file" do
+          it 'places feature assignment at the top of the file' do
+            write_file("app/test.#{jslike_filetype}", <<~CONTENTS)
+              class Rectangle {
+                constructor(height, width) {
+                  this.height = height;
+                  this.width = width;
+                }
+              }
+            CONTENTS
+
+            described_class.apply_assignments!([["app/test.#{jslike_filetype}", 'Foo']])
+
+            expect(File.read("app/test.#{jslike_filetype}")).to eq(<<~CONTENTS)
+              // @feature Foo
+
+              class Rectangle {
+                constructor(height, width) {
+                  this.height = height;
+                  this.width = width;
+                }
+              }
+            CONTENTS
+          end
+
+          it 'ignores files that already have an assignment' do
+            write_file("app/test.#{jslike_filetype}", <<~CONTENTS)
+              // @feature Bar
+
+              class Rectangle {
+                constructor(height, width) {
+                  this.height = height;
+                  this.width = width;
+                }
+              }
+            CONTENTS
+
+            expect do
+              described_class.apply_assignments!([["app/test.#{jslike_filetype}", 'Foo']])
+            end.to output("Already assigned: app/test.#{jslike_filetype}, Foo\n").to_stdout
+
+            expect(File.read("app/test.#{jslike_filetype}")).to eq(<<~CONTENTS)
+              // @feature Bar
+
+              class Rectangle {
+                constructor(height, width) {
+                  this.height = height;
+                  this.width = width;
+                }
+              }
+            CONTENTS
+          end
+        end
+      end
+
+      context 'when assigning into a .rb file' do
+        it 'places feature assignment at the top of the file' do
+          write_file('app/test.rb', <<~CONTENTS)
+            # frozen_string_literal: true
+
+            class Foo
+              def initialize(val)
+                @val = val
+              end
+            end
+          CONTENTS
+
+          described_class.apply_assignments!([['app/test.rb', 'Foo']])
+
+          expect(File.read('app/test.rb')).to eq(<<~CONTENTS)
+            # @feature Foo
+            # frozen_string_literal: true
+
+            class Foo
+              def initialize(val)
+                @val = val
+              end
+            end
+          CONTENTS
+        end
+
+        it 'ignores files that already have an assignment' do
+          write_file('app/test.rb', <<~CONTENTS)
+            # @feature Bar
+            # frozen_string_literal: true
+
+            class Foo
+              def initialize(val)
+                @val = val
+              end
+            end
+          CONTENTS
+
+          expect do
+            described_class.apply_assignments!([['app/test.rb', 'Foo']])
+          end.to output("Already assigned: app/test.rb, Foo\n").to_stdout
+
+          expect(File.read('app/test.rb')).to eq(<<~CONTENTS)
+            # @feature Bar
+            # frozen_string_literal: true
+
+            class Foo
+              def initialize(val)
+                @val = val
+              end
+            end
+          CONTENTS
+        end
+      end
+
+      context 'when assigning into a .xml file' do
+        it 'places feature assignment after xml declaration if available' do
+          write_file('app/test.xml', <<~CONTENTS)
+            <?xml version="1.0" encoding="UTF-8"?>
+            <Thing>
+              <InnerThing />
+            </Thing>
+          CONTENTS
+
+          write_file('app/test-missing-xml.xml', <<~CONTENTS)
+            <Thing>
+              <InnerThing />
+            </Thing>
+          CONTENTS
+
+          write_file('app/test-top-comment.xml', <<~CONTENTS)
+            <!--
+              A long
+              multiline
+              comment
+            -->
+            <?xml version="1.0" encoding="UTF-8"?>
+            <Thing>
+              <InnerThing />
+            </Thing>
+          CONTENTS
+
+          described_class.apply_assignments!([['app/test.xml', 'Foo'], ['app/test-missing-xml.xml', 'Foo'], ['app/test-top-comment.xml', 'Foo']])
+
+          expect(File.read('app/test.xml')).to eq(<<~CONTENTS)
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!-- @feature Foo -->
+
+            <Thing>
+              <InnerThing />
+            </Thing>
+          CONTENTS
+
+          expect(File.read('app/test-missing-xml.xml')).to eq(<<~CONTENTS)
+            <!-- @feature Foo -->
+
+            <Thing>
+              <InnerThing />
+            </Thing>
+          CONTENTS
+
+          expect(File.read('app/test-top-comment.xml')).to eq(<<~CONTENTS)
+            <!--
+              A long
+              multiline
+              comment
+            -->
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!-- @feature Foo -->
+
+            <Thing>
+              <InnerThing />
+            </Thing>
+          CONTENTS
+        end
+
+        it 'ignores files that already have an assignment' do
+          write_file('app/test.xml', <<~CONTENTS)
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!-- @feature Bar -->
+
+            <Thing>
+              <InnerThing />
+            </Thing>
+          CONTENTS
+
+          expect do
+            described_class.apply_assignments!([['app/test.xml', 'Foo']])
+          end.to output("Already assigned: app/test.xml, Foo\n").to_stdout
+
+          expect(File.read('app/test.xml')).to eq(<<~CONTENTS)
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!-- @feature Bar -->
+
+            <Thing>
+              <InnerThing />
+            </Thing>
+          CONTENTS
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/feature_map_spec.rb
+++ b/spec/lib/feature_map_spec.rb
@@ -308,6 +308,32 @@ RSpec.describe FeatureMap do
     end
   end
 
+  describe '.apply_assignments!' do
+    before do
+      create_test_coverage_artifacts
+
+      write_file('tmp/assignments.csv', <<~CONTENTS)
+        app/foo.rb,Foo
+      CONTENTS
+      write_file('app/foo.rb', <<~CONTENTS)
+        class Foo
+        end
+      CONTENTS
+    end
+
+    it 'applies assignments' do
+      FeatureMap.apply_assignments!(
+        'tmp/assignments.csv'
+      )
+
+      expect(File.read('app/foo.rb')).to eq(<<~CONTENTS)
+        # @feature Foo
+        class Foo
+        end
+      CONTENTS
+    end
+  end
+
   describe '.gather_test_coverage!' do
     let(:commit_sha) { '1234567890abcdef1234567890abcdef' }
     let(:code_cov_token) { 'e5124eb5-c948-4136-9297-08efa6f2d537' }

--- a/spec/support/application_fixtures.rb
+++ b/spec/support/application_fixtures.rb
@@ -2,7 +2,7 @@ RSpec.shared_context 'application fixtures' do
   let(:assignments_file_path) { Pathname.pwd.join('.feature_map/assignments.yml') }
 
   def write_configuration(assigned_globs: nil, **kwargs)
-    assigned_globs ||= ['{app,components,config,frontend,lib,packs,spec}/**/*.{rb,rake,js,jsx,ts,tsx,json,yml}']
+    assigned_globs ||= ['{app,components,config,frontend,lib,packs,spec}/**/*.{rb,rake,js,jsx,ts,tsx,json,yml,cls,xml,html}']
     config = {
       'assigned_globs' => assigned_globs,
       'unassigned_globs' => ['.feature_map/config.yml']


### PR DESCRIPTION
Adds a script to apply assignments based on a provided `assignments.csv`.  Supports all of the languages for which we support comment annotations, plus directory-level `.feature` file assignment.  Specs speak best to the behavior, with a quick-and-dirty demo:  https://linear.app/bf-settlements/issue/FEAT-113#comment-5c9ffe53