### PR TITLE
FEAT-94 | Release Notification Generation

### DIFF
--- a/feature_map.gemspec
+++ b/feature_map.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'packs-specification', '~> 0.0'
   spec.add_dependency 'rubocop', '~> 1.0'
   spec.add_dependency 'sorbet-runtime', '~> 0.5'
+  spec.add_dependency 'uri', '~> 1.0'
 
   spec.add_development_dependency 'debug', '~> 1.9'
   spec.add_development_dependency 'railties', '~> 7.2'

--- a/feature_map.gemspec
+++ b/feature_map.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'feature_map'
-  spec.version       = '1.1.1'
+  spec.version       = '1.2.0'
   spec.authors       = ['Beyond Finance']
   spec.email         = ['engineering@beyondfinance.com']
   spec.summary       = 'A gem to help identify and manage features within large Ruby and Rails applications'

--- a/lib/feature_map.rb
+++ b/lib/feature_map.rb
@@ -6,6 +6,7 @@ require 'set'
 require 'sorbet-runtime'
 require 'json'
 require 'yaml'
+require 'feature_map/commit'
 require 'feature_map/code_features'
 require 'feature_map/mapper'
 require 'feature_map/validator'
@@ -14,6 +15,8 @@ require 'feature_map/cli'
 require 'feature_map/configuration'
 
 module FeatureMap
+  ALL_TEAMS_KEY = 'All Teams'
+
   module_function
 
   extend T::Sig
@@ -21,6 +24,9 @@ module FeatureMap
 
   requires_ancestor { Kernel }
   GlobsToAssignedFeatureMap = T.type_alias { T::Hash[String, CodeFeatures::Feature] }
+
+  UpdatedFeaturesByTeam = T.type_alias { T::Hash[String, CommitsByFeature] }
+  CommitsByFeature = T.type_alias { T::Hash[String, T::Array[Commit]] }
 
   sig { params(assignments_file_path: String).void }
   def apply_assignments!(assignments_file_path)
@@ -196,6 +202,35 @@ module FeatureMap
       @memoized_values[klass.to_s] = value_to_memoize
       value_to_memoize
     end
+  end
+
+  # Groups the provided list of commits (e.g. the changes being deployed in a release) by both the feature they impact
+  # and the teams responsible for these features. Returns a hash with keys for each team with features modified within
+  # these commits and values that are a hash of features to the set of commits that impact each feature.
+  sig { params(commits: T::Array[Commit]).returns(UpdatedFeaturesByTeam) }
+  def group_commits(commits)
+    commits.each_with_object({}) do |commit, hash|
+      commit.files.each do |file|
+        feature = FeatureMap.for_file(file)
+        next unless feature
+
+        teams = Private.all_teams_for_feature(feature)
+        team_names = teams.empty? ? [ALL_TEAMS_KEY] : teams.map(&:name)
+
+        team_names.sort.each do |team_name|
+          hash[team_name] ||= {}
+          hash[team_name][feature.name] ||= []
+          hash[team_name][feature.name] << commit.sha
+        end
+      end
+    end
+  end
+
+  # Generates a block kit message grouping the provided commits into sections for each feature impacted by the
+  # cheanges.
+  sig { params(commits_by_feature: CommitsByFeature).returns(T::Array[T::Hash[String, T.untyped]]) }
+  def generate_release_notification(commits_by_feature)
+    Private.generate_release_notification(commits_by_feature)
   end
 
   # Generally, you should not ever need to do this, because once your ruby process loads, cached content should not change.

--- a/lib/feature_map.rb
+++ b/lib/feature_map.rb
@@ -221,7 +221,7 @@ module FeatureMap
         team_names.sort.each do |team_name|
           hash[team_name] ||= {}
           hash[team_name][feature.name] ||= []
-          hash[team_name][feature.name] << commit.sha
+          hash[team_name][feature.name] << commit
         end
 
         feature
@@ -233,7 +233,7 @@ module FeatureMap
 
       hash[ALL_TEAMS_KEY] ||= {}
       hash[ALL_TEAMS_KEY][NO_FEATURE_KEY] ||= []
-      hash[ALL_TEAMS_KEY][NO_FEATURE_KEY] << commit.sha
+      hash[ALL_TEAMS_KEY][NO_FEATURE_KEY] << commit
     end
   end
 

--- a/lib/feature_map.rb
+++ b/lib/feature_map.rb
@@ -221,7 +221,7 @@ module FeatureMap
         team_names.sort.each do |team_name|
           hash[team_name] ||= {}
           hash[team_name][feature.name] ||= []
-          hash[team_name][feature.name] << commit
+          hash[team_name][feature.name] << commit unless hash[team_name][feature.name].include?(commit)
         end
 
         feature

--- a/lib/feature_map/commit.rb
+++ b/lib/feature_map/commit.rb
@@ -1,0 +1,34 @@
+# typed: strict
+
+module FeatureMap
+  class Commit
+    extend T::Sig
+
+    sig { returns(T.nilable(String)) }
+    attr_reader :sha
+
+    sig { returns(T.nilable(String)) }
+    attr_reader :description
+
+    sig { returns(T.nilable(String)) }
+    attr_reader :pull_request_number
+
+    sig { returns(T::Array[String]) }
+    attr_reader :files
+
+    sig do
+      params(
+        sha: T.nilable(String),
+        description: T.nilable(String),
+        pull_request_number: T.nilable(String),
+        files: T::Array[String]
+      ).void
+    end
+    def initialize(sha: nil, description: nil, pull_request_number: nil, files: [])
+      @sha = sha
+      @description = description
+      @pull_request_number = pull_request_number
+      @files = files
+    end
+  end
+end

--- a/lib/feature_map/configuration.rb
+++ b/lib/feature_map/configuration.rb
@@ -15,6 +15,7 @@ module FeatureMap
     const :code_cov, T::Hash[String, T.nilable(String)]
     const :repository, T::Hash[String, T.nilable(String)]
     const :documentation_site, T::Hash[String, T.untyped]
+    const :documentation_site_url, T.nilable(String)
 
     sig { returns(Configuration) }
     def self.fetch
@@ -36,7 +37,8 @@ module FeatureMap
         ignore_feature_definitions: config_hash.fetch('ignore_feature_definitions', false),
         code_cov: config_hash.fetch('code_cov', {}),
         repository: config_hash.fetch('repository', {}),
-        documentation_site: config_hash.fetch('documentation_site', {})
+        documentation_site: config_hash.fetch('documentation_site', {}),
+        documentation_site_url: config_hash.fetch('documentation_site_url', nil)
       )
     end
   end

--- a/lib/feature_map/private/assignments_file.rb
+++ b/lib/feature_map/private/assignments_file.rb
@@ -1,6 +1,8 @@
 # typed: strict
 # frozen_string_literal: true
 
+require 'code_ownership'
+
 module FeatureMap
   module Private
     #

--- a/lib/feature_map/private/release_notification_builder.rb
+++ b/lib/feature_map/private/release_notification_builder.rb
@@ -1,0 +1,76 @@
+# typed: strict
+# frozen_string_literal: true
+
+module FeatureMap
+  module Private
+    #
+    # This class is responsible for building a release notification message that can be published to a single
+    # team or to an organization as a whole. Currently, the only supported output format is Slack's Block Kit
+    # (see https://app.slack.com/block-kit-builder).
+    #
+    class ReleaseNotificationBuilder
+      extend T::Sig
+
+      BlockKitSection = T.type_alias { T::Hash[String, T.untyped] }
+      BlockKitPayload = T.type_alias { T::Array[T::Hash[String, T.untyped]] }
+
+      class << self
+        extend T::Sig
+
+        sig { params(commits_by_feature: CommitsByFeature).returns(BlockKitPayload) }
+        def build(commits_by_feature)
+          return [] if commits_by_feature.empty?
+
+          feature_names = commits_by_feature.keys.sort
+
+          feature_names.flat_map.with_index do |feature_name, index|
+            # Insert a divider between each feature but not above the first feature nor below the last feature.
+            divider = index.zero? ? [] : [{ type: 'divider' }]
+            divider + [build_feature_section(feature_name, T.must(commits_by_feature[feature_name]))]
+          end
+        end
+
+        private
+
+        sig { params(feature_name: String, commits: T::Array[Commit]).returns(BlockKitSection) }
+        def build_feature_section(feature_name, commits)
+          feature_header_markdown = "*_#{feature_name}_*"
+
+          # If the docs site is hosted at a persistent URL, include a link to the feature show page.
+          if documentation_site_url
+            feature_header_markdown += " (<#{documentation_site_url}#/#{URI::DEFAULT_PARSER.escape(feature_name)}|View Documentation>)"
+          end
+
+          feature_markdown_lines = [feature_header_markdown]
+          commits.each do |commit|
+            commit_sub_bullet = "• #{commit.description}"
+
+            if repository_url && commit.pull_request_number
+              commit_sub_bullet += " (<#{repository_url}/pull/#{commit.pull_request_number}|##{commit.pull_request_number}>)"
+            end
+
+            feature_markdown_lines << commit_sub_bullet
+          end
+
+          {
+            type: 'section',
+            text: {
+              type: 'mrkdwn',
+              text: feature_markdown_lines.join("\n")
+            }
+          }
+        end
+
+        sig { returns(T.nilable(String)) }
+        def documentation_site_url
+          Private.configuration.documentation_site_url
+        end
+
+        sig { returns(T.nilable(String)) }
+        def repository_url
+          Private.configuration.repository['url']
+        end
+      end
+    end
+  end
+end

--- a/lib/feature_map/private/release_notification_builder.rb
+++ b/lib/feature_map/private/release_notification_builder.rb
@@ -37,7 +37,7 @@ module FeatureMap
           feature_header_markdown = "*_#{feature_name}_*"
 
           # If the docs site is hosted at a persistent URL, include a link to the feature show page.
-          if documentation_site_url
+          if documentation_site_url && feature_name != FeatureMap::NO_FEATURE_KEY
             feature_header_markdown += " (<#{documentation_site_url}#/#{URI::DEFAULT_PARSER.escape(feature_name)}|View Documentation>)"
           end
 

--- a/sorbet/rbi/code_teams.rbi
+++ b/sorbet/rbi/code_teams.rbi
@@ -1,0 +1,119 @@
+# typed: true
+
+# DO NOT EDIT MANUALLY
+# This file was copied from https://github.com/rubyatscale/code_ownership/blob/2b233e5d60deb228f9363d59ca3992d1ce610251/sorbet/rbi/gems/code_teams%401.0.0.rbi
+
+module CodeTeams
+  class << self
+    sig { returns(T::Array[::CodeTeams::Team]) }
+    def all; end
+
+    sig { void }
+    def bust_caches!; end
+
+    sig { params(name: ::String).returns(T.nilable(::CodeTeams::Team)) }
+    def find(name); end
+
+    sig { params(dir: ::String).returns(T::Array[::CodeTeams::Team]) }
+    def for_directory(dir); end
+
+    sig { params(string: ::String).returns(::String) }
+    def tag_value_for(string); end
+
+    sig { params(teams: T::Array[::CodeTeams::Team]).returns(T::Array[::String]) }
+    def validation_errors(teams); end
+  end
+end
+
+class CodeTeams::IncorrectPublicApiUsageError < ::StandardError; end
+
+class CodeTeams::Plugin
+  abstract!
+
+  sig { params(team: ::CodeTeams::Team).void }
+  def initialize(team); end
+
+  class << self
+    sig { returns(T::Array[T.class_of(CodeTeams::Plugin)]) }
+    def all_plugins; end
+
+    sig { params(team: ::CodeTeams::Team).returns(T.attached_class) }
+    def for(team); end
+
+    sig { params(base: T.untyped).void }
+    def inherited(base); end
+
+    sig { params(team: ::CodeTeams::Team, key: ::String).returns(::String) }
+    def missing_key_error_message(team, key); end
+
+    sig { params(teams: T::Array[::CodeTeams::Team]).returns(T::Array[::String]) }
+    def validation_errors(teams); end
+
+    private
+
+    sig { params(team: ::CodeTeams::Team).returns(T.attached_class) }
+    def register_team(team); end
+
+    sig { returns(T::Hash[T.nilable(::String), T::Hash[::Class, ::CodeTeams::Plugin]]) }
+    def registry; end
+  end
+end
+
+module CodeTeams::Plugins; end
+
+class CodeTeams::Plugins::Identity < ::CodeTeams::Plugin
+  sig { returns(::CodeTeams::Plugins::Identity::IdentityStruct) }
+  def identity; end
+
+  class << self
+    sig { override.params(teams: T::Array[::CodeTeams::Team]).returns(T::Array[::String]) }
+    def validation_errors(teams); end
+  end
+end
+
+class CodeTeams::Plugins::Identity::IdentityStruct < ::Struct
+  def name; end
+  def name=(_); end
+
+  class << self
+    def [](*_arg0); end
+    def inspect; end
+    def members; end
+    def new(*_arg0); end
+  end
+end
+
+class CodeTeams::Team
+  sig { params(config_yml: T.nilable(::String), raw_hash: T::Hash[T.untyped, T.untyped]).void }
+  def initialize(config_yml:, raw_hash:); end
+
+  sig { params(other: ::Object).returns(T::Boolean) }
+  def ==(other); end
+
+  sig { returns(T.nilable(::String)) }
+  def config_yml; end
+
+  def eql?(*args, &blk); end
+
+  sig { returns(::Integer) }
+  def hash; end
+
+  sig { returns(::String) }
+  def name; end
+
+  sig { returns(T::Hash[T.untyped, T.untyped]) }
+  def raw_hash; end
+
+  sig { returns(::String) }
+  def to_tag; end
+
+  class << self
+    sig { params(raw_hash: T::Hash[T.untyped, T.untyped]).returns(::CodeTeams::Team) }
+    def from_hash(raw_hash); end
+
+    sig { params(config_yml: ::String).returns(::CodeTeams::Team) }
+    def from_yml(config_yml); end
+  end
+end
+
+CodeTeams::UNKNOWN_TEAM_STRING = T.let(T.unsafe(nil), String)

--- a/spec/lib/feature_map/commit_spec.rb
+++ b/spec/lib/feature_map/commit_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe FeatureMap::Commit do
+  describe '.new' do
+    it 'persists all attributes' do
+      commit = described_class.new(sha: '123abc', description: 'Test commit message.', pull_request_number: '1000', files: ['app/my_file.rb', 'app/my_error.rb'])
+      expect(commit.sha).to eq('123abc')
+      expect(commit.description).to eq('Test commit message.')
+      expect(commit.pull_request_number).to eq('1000')
+      expect(commit.files).to eq(['app/my_file.rb', 'app/my_error.rb'])
+    end
+
+    it 'assigns a default value for each attribute' do
+      commit = described_class.new
+      expect(commit.sha).to be_nil
+      expect(commit.description).to be_nil
+      expect(commit.pull_request_number).to be_nil
+      expect(commit.files).to eq([])
+    end
+  end
+end

--- a/spec/lib/feature_map/private/assignments_file_spec.rb
+++ b/spec/lib/feature_map/private/assignments_file_spec.rb
@@ -265,7 +265,6 @@ module FeatureMap
         before do
           create_files_with_defined_classes
           create_files_with_team_assignments
-          write_configuration('unassigned_globs' => ['.feature_map/config.yml', 'config/code_ownership.yml'], 'skip_code_ownership' => false)
         end
 
         let(:expected_lines) do
@@ -632,7 +631,8 @@ module FeatureMap
 
       it 'returns the feature metrics details from the existing Metrics File' do
         expect(Private::AssignmentsFile.load_features!).to eq({
-                                                                'Bar' => ['app/my_error.rb']
+                                                                'Bar' => { 'files' => ['app/my_error.rb'] },
+                                                                'Foo' => { 'files' => ['app/my_file.rb'] }
                                                               })
       end
 

--- a/spec/lib/feature_map/private/release_notification_builder_spec.rb
+++ b/spec/lib/feature_map/private/release_notification_builder_spec.rb
@@ -1,0 +1,157 @@
+# typed: false
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module FeatureMap
+  RSpec.describe Private::ReleaseNotificationBuilder do
+    describe '.build' do
+      before { create_files_with_defined_classes }
+
+      context 'when an empty set of commits is provided' do
+        it 'returns an empty array' do
+          payload = described_class.build({})
+          expect(payload).to eq([])
+        end
+      end
+
+      context 'when both a repository URL and a documentation site URL are configured' do
+        before do
+          write_configuration(
+            'repository' => {
+              'main_branch' => 'main',
+              'url' => 'https://github.com/test-org/feature_map'
+            },
+            'documentation_site_url' => 'https://test-org.github.io/feature_map/'
+          )
+        end
+
+        context 'when a single commit, impacting a single feature is provided' do
+          let(:commit) { Commit.new(sha: 'abc123', description: 'A test change of Foo.', pull_request_number: '123', files: ['app/my_file.rb']) }
+          let(:commits_by_feature) { { 'Foo' => [commit] } }
+
+          it 'generates the appropriate block kit payload' do
+            payload = described_class.build(commits_by_feature)
+            expect(payload).to eq([
+                                    {
+                                      type: 'section',
+                                      text: {
+                                        type: 'mrkdwn',
+                                        text: "*_Foo_* (<https://test-org.github.io/feature_map/#/Foo|View Documentation>)\n• A test change of Foo. (<https://github.com/test-org/feature_map/pull/123|#123>)"
+                                      }
+                                    }
+                                  ])
+          end
+        end
+
+        context 'when a single commit, impacting multiple features is provided' do
+          let(:commit) { Commit.new(sha: 'abc123', description: 'A test change impacting both Foo and Bar.', pull_request_number: '123', files: ['app/my_file.rb', 'app/my_error.rb']) }
+          let(:commits_by_feature) { { 'Foo' => [commit], 'Bar' => [commit] } }
+
+          it 'generates the appropriate block kit payload' do
+            payload = described_class.build(commits_by_feature)
+            expect(payload).to eq([
+                                    {
+                                      type: 'section',
+                                      text: {
+                                        type: 'mrkdwn',
+                                        text: "*_Bar_* (<https://test-org.github.io/feature_map/#/Bar|View Documentation>)\n• A test change impacting both Foo and Bar. (<https://github.com/test-org/feature_map/pull/123|#123>)"
+                                      }
+                                    },
+                                    { type: 'divider' },
+                                    {
+                                      type: 'section',
+                                      text: {
+                                        type: 'mrkdwn',
+                                        text: "*_Foo_* (<https://test-org.github.io/feature_map/#/Foo|View Documentation>)\n• A test change impacting both Foo and Bar. (<https://github.com/test-org/feature_map/pull/123|#123>)"
+                                      }
+                                    }
+                                  ])
+          end
+        end
+
+        context 'when multiple commits, impacting a single feature are provided' do
+          let(:foo_commit1) { Commit.new(sha: 'abc123', description: 'A test change of Foo.', pull_request_number: '123', files: ['app/my_file.rb']) }
+          let(:foo_commit2) { Commit.new(sha: '987def', description: 'Another change impacting Foo.', pull_request_number: '987', files: ['app/my_file.rb']) }
+          let(:commits_by_feature) { { 'Foo' => [foo_commit1, foo_commit2] } }
+
+          it 'generates the appropriate block kit payload' do
+            payload = described_class.build(commits_by_feature)
+            expect(payload).to eq([
+                                    {
+                                      type: 'section',
+                                      text: {
+                                        type: 'mrkdwn',
+                                        text: "*_Foo_* (<https://test-org.github.io/feature_map/#/Foo|View Documentation>)\n• A test change of Foo. (<https://github.com/test-org/feature_map/pull/123|#123>)\n• Another change impacting Foo. (<https://github.com/test-org/feature_map/pull/987|#987>)"
+                                      }
+                                    }
+                                  ])
+          end
+        end
+
+        context 'when multiple commits, impacting a multiple features are provided' do
+          let(:foo_commit) { Commit.new(sha: 'aaa111', description: 'A test change of Foo.', pull_request_number: '111', files: ['app/my_file.rb']) }
+          let(:bar_commit) { Commit.new(sha: 'bbb222', description: 'A test change of Bar.', pull_request_number: '222', files: ['app/my_error.rb']) }
+          let(:commits_by_feature) { { 'Foo' => [foo_commit], 'Bar' => [bar_commit] } }
+
+          it 'generates the appropriate block kit payload' do
+            payload = described_class.build(commits_by_feature)
+            expect(payload).to eq([
+                                    {
+                                      type: 'section',
+                                      text: {
+                                        type: 'mrkdwn',
+                                        text: "*_Bar_* (<https://test-org.github.io/feature_map/#/Bar|View Documentation>)\n• A test change of Bar. (<https://github.com/test-org/feature_map/pull/222|#222>)"
+                                      }
+                                    },
+                                    { type: 'divider' },
+                                    {
+                                      type: 'section',
+                                      text: {
+                                        type: 'mrkdwn',
+                                        text: "*_Foo_* (<https://test-org.github.io/feature_map/#/Foo|View Documentation>)\n• A test change of Foo. (<https://github.com/test-org/feature_map/pull/111|#111>)"
+                                      }
+                                    }
+                                  ])
+          end
+        end
+
+        context 'when a commits has no associated pull request' do
+          let(:commit) { Commit.new(sha: 'aaa111', description: 'A test change of Foo.', files: ['app/my_file.rb']) }
+          let(:commits_by_feature) { { 'Foo' => [commit] } }
+
+          it 'generates a block kit payload with no pull request link' do
+            payload = described_class.build(commits_by_feature)
+            expect(payload).to eq([
+                                    {
+                                      type: 'section',
+                                      text: {
+                                        type: 'mrkdwn',
+                                        text: "*_Foo_* (<https://test-org.github.io/feature_map/#/Foo|View Documentation>)\n• A test change of Foo."
+                                      }
+                                    }
+                                  ])
+          end
+        end
+      end
+
+      context 'when the repository URL and documentation site URL are NOT configured' do
+        let(:commit) { Commit.new(sha: 'abc123', description: 'A test change of Foo.', pull_request_number: '123', files: ['app/my_file.rb']) }
+        let(:commits_by_feature) { { 'Foo' => [commit] } }
+
+        it 'omits the documentation link and PR link from the block kit payload' do
+          payload = described_class.build(commits_by_feature)
+          expect(payload).to eq([
+                                  {
+                                    type: 'section',
+                                    text: {
+                                      type: 'mrkdwn',
+                                      text: "*_Foo_*\n• A test change of Foo."
+                                    }
+                                  }
+                                ])
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/feature_map/private/release_notification_builder_spec.rb
+++ b/spec/lib/feature_map/private/release_notification_builder_spec.rb
@@ -133,6 +133,33 @@ module FeatureMap
                                   ])
           end
         end
+
+        context 'when set of commits include a \'No Feature\' secton' do
+          let(:commit) { Commit.new(sha: 'aaa111', description: 'A test change of Foo.', files: ['app/my_file.rb']) }
+          let(:featureless_commit) { Commit.new(sha: 'ddd444', description: 'Change to files that are not assigned to any feature.', files: ['app/featureless_file.rb']) }
+          let(:commits_by_feature) { { 'Foo' => [commit], 'No Feature' => [featureless_commit] } }
+
+          it 'excludes the documentation site link for the \'No Feature\' section' do
+            payload = described_class.build(commits_by_feature)
+            expect(payload).to eq([
+                                    {
+                                      type: 'section',
+                                      text: {
+                                        type: 'mrkdwn',
+                                        text: "*_Foo_* (<https://test-org.github.io/feature_map/#/Foo|View Documentation>)\n• A test change of Foo."
+                                      }
+                                    },
+                                    { type: 'divider' },
+                                    {
+                                      type: 'section',
+                                      text: {
+                                        type: 'mrkdwn',
+                                        text: "*_No Feature_*\n• Change to files that are not assigned to any feature."
+                                      }
+                                    }
+                                  ])
+          end
+        end
       end
 
       context 'when the repository URL and documentation site URL are NOT configured' do

--- a/spec/lib/feature_map/private/validations/files_have_features_spec.rb
+++ b/spec/lib/feature_map/private/validations/files_have_features_spec.rb
@@ -105,7 +105,7 @@ module FeatureMap
             context 'when the file is assigned to a team that IS NOT in the require_assignment_for_teams set' do
               before do
                 write_file('config/teams/unassigned_team.yml', <<~CONTENTS)
-                  name: UnAssigned Team
+                  name: Unassigned Team
                   github:
                     team: '@My-Org/unassigned-team'
                   owned_globs: ['app/missing_assignment.rb']

--- a/spec/lib/feature_map_spec.rb
+++ b/spec/lib/feature_map_spec.rb
@@ -428,20 +428,14 @@ RSpec.describe FeatureMap do
           assigned_globs:
             - app/shared.rb
         CONTENTS
-        shared_commit = FeatureMap::Commit.new(sha: 'fff555', description: 'Change to a feature with no assigned team.', files: ['app/shared.rb'])
+        shared_commit = FeatureMap::Commit.new(sha: 'fff666', description: 'Change to a feature with no assigned team.', files: ['app/shared.rb'])
 
         grouped_commits = FeatureMap.group_commits([shared_commit])
         expect(grouped_commits).to eq({
                                         'All Teams' => {
-                                          'Shared' => ['fff555']
+                                          'Shared' => ['fff666']
                                         }
                                       })
-      end
-
-      it 'ignores files with no assigned feature' do
-        featureless_commit = FeatureMap::Commit.new(sha: 'fff555', description: 'Change to a file with no feature.', files: ['app/featureless.rb'])
-        grouped_commits = FeatureMap.group_commits([featureless_commit])
-        expect(grouped_commits).to eq({})
       end
 
       it 'lists only features modified within the specified commits' do
@@ -454,14 +448,32 @@ RSpec.describe FeatureMap do
       end
 
       it 'lists teams who are responsible for any file of a features modified within the specified commits, even if the teams files were NOT modified in the specified commits' do
-        team_a_commit = FeatureMap::Commit.new(sha: 'eee444', description: 'Change made by Team A to a Foo file.', files: ['app/foo_stuff_owned_by_team_a.rb'])
+        team_a_commit = FeatureMap::Commit.new(sha: 'eee555', description: 'Change made by Team A to a Foo file.', files: ['app/foo_stuff_owned_by_team_a.rb'])
         grouped_commits = FeatureMap.group_commits([team_a_commit])
         expect(grouped_commits).to eq({
                                         'Team A' => {
-                                          'Foo' => ['eee444']
+                                          'Foo' => ['eee555']
                                         },
                                         'Team B' => {
-                                          'Foo' => ['eee444']
+                                          'Foo' => ['eee555']
+                                        }
+                                      })
+      end
+
+      it 'lists commits that change that have no responsible team under a key representing all teams' do
+        write_file('app/featureless_file.rb', 'class FeaturelessClass; end')
+        featureless_commit = FeatureMap::Commit.new(sha: 'ddd444', description: 'Change to files that are not assigned to any feature.', files: ['app/featureless_file.rb'])
+
+        grouped_commits = FeatureMap.group_commits([featureless_commit, foo_commit])
+        expect(grouped_commits).to eq({
+                                        'All Teams' => {
+                                          'No Feature' => ['ddd444']
+                                        },
+                                        'Team A' => {
+                                          'Foo' => ['bbb222']
+                                        },
+                                        'Team B' => {
+                                          'Foo' => ['bbb222']
                                         }
                                       })
       end

--- a/spec/lib/feature_map_spec.rb
+++ b/spec/lib/feature_map_spec.rb
@@ -421,7 +421,20 @@ RSpec.describe FeatureMap do
                                       })
       end
 
-      it 'lists features that have no responsible team unde a key representing all teams' do
+      it 'does not duplicate commits with multiple files for the same feature' do
+        multi_file_commit = FeatureMap::Commit.new(sha: 'abc123', description: 'Changes to multiple Foo files.', files: ['app/my_file.rb', 'app/foo_stuff_owned_by_team_a.rb'])
+        grouped_commits = FeatureMap.group_commits([multi_file_commit])
+        expect(grouped_commits).to eq({
+                                        'Team A' => {
+                                          'Foo' => [multi_file_commit]
+                                        },
+                                        'Team B' => {
+                                          'Foo' => [multi_file_commit]
+                                        }
+                                      })
+      end
+
+      it 'lists features that have no responsible team under a key representing all teams' do
         write_file('app/shared.rb', 'class Shared; end')
         write_file('.feature_map/definitions/shared.yml', <<~CONTENTS)
           name: Shared

--- a/spec/lib/feature_map_spec.rb
+++ b/spec/lib/feature_map_spec.rb
@@ -381,8 +381,8 @@ RSpec.describe FeatureMap do
         grouped_commits = FeatureMap.group_commits([foo_commit, foo_and_bar_commit, bar_commit])
         expect(grouped_commits).to eq({
                                         'All Teams' => {
-                                          'Foo' => %w[bbb222 aaa111],
-                                          'Bar' => %w[aaa111 ccc333]
+                                          'Foo' => [foo_commit, foo_and_bar_commit],
+                                          'Bar' => [foo_and_bar_commit, bar_commit]
                                         }
                                       })
       end
@@ -412,11 +412,11 @@ RSpec.describe FeatureMap do
         grouped_commits = FeatureMap.group_commits([foo_commit, foo_and_bar_commit, bar_commit])
         expect(grouped_commits).to eq({
                                         'Team A' => {
-                                          'Foo' => %w[bbb222 aaa111]
+                                          'Foo' => [foo_commit, foo_and_bar_commit]
                                         },
                                         'Team B' => {
-                                          'Foo' => %w[bbb222 aaa111],
-                                          'Bar' => %w[aaa111 ccc333]
+                                          'Foo' => [foo_commit, foo_and_bar_commit],
+                                          'Bar' => [foo_and_bar_commit, bar_commit]
                                         }
                                       })
       end
@@ -433,7 +433,7 @@ RSpec.describe FeatureMap do
         grouped_commits = FeatureMap.group_commits([shared_commit])
         expect(grouped_commits).to eq({
                                         'All Teams' => {
-                                          'Shared' => ['fff666']
+                                          'Shared' => [shared_commit]
                                         }
                                       })
       end
@@ -442,7 +442,7 @@ RSpec.describe FeatureMap do
         grouped_commits = FeatureMap.group_commits([bar_commit])
         expect(grouped_commits).to eq({
                                         'Team B' => {
-                                          'Bar' => ['ccc333']
+                                          'Bar' => [bar_commit]
                                         }
                                       })
       end
@@ -452,10 +452,10 @@ RSpec.describe FeatureMap do
         grouped_commits = FeatureMap.group_commits([team_a_commit])
         expect(grouped_commits).to eq({
                                         'Team A' => {
-                                          'Foo' => ['eee555']
+                                          'Foo' => [team_a_commit]
                                         },
                                         'Team B' => {
-                                          'Foo' => ['eee555']
+                                          'Foo' => [team_a_commit]
                                         }
                                       })
       end
@@ -467,13 +467,13 @@ RSpec.describe FeatureMap do
         grouped_commits = FeatureMap.group_commits([featureless_commit, foo_commit])
         expect(grouped_commits).to eq({
                                         'All Teams' => {
-                                          'No Feature' => ['ddd444']
+                                          'No Feature' => [featureless_commit]
                                         },
                                         'Team A' => {
-                                          'Foo' => ['bbb222']
+                                          'Foo' => [foo_commit]
                                         },
                                         'Team B' => {
-                                          'Foo' => ['bbb222']
+                                          'Foo' => [foo_commit]
                                         }
                                       })
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require 'rubocop'
 require 'feature_map'
 require 'packs-specification'
 require 'packs/rspec/support' # Provides Rspec wrappers that support and isolate test files setup.
+# See more at https://github.com/rubyatscale/packs-specification/blob/71336be896386c5527dac9aa935deb3ae3fe3828/lib/packs/rspec/support.rb#L3
 require_relative 'support/application_fixtures'
 
 RSpec.configure do |config|
@@ -28,6 +29,8 @@ RSpec.configure do |config|
     unless c.metadata[:do_not_bust_cache]
       FeatureMap.bust_caches!
       FeatureMap::CodeFeatures.bust_caches!
+      CodeOwnership.bust_caches!
+      CodeTeams.bust_caches!
     end
   end
 end

--- a/spec/support/application_fixtures.rb
+++ b/spec/support/application_fixtures.rb
@@ -157,6 +157,8 @@ RSpec.shared_context 'application fixtures' do
     require Pathname.pwd.join('app/foo_stuff_owned_by_team_a')
     require Pathname.pwd.join('app/foo_stuff_owned_by_team_b')
     require Pathname.pwd.join('app/other_team_b_stuff')
+
+    write_configuration('unassigned_globs' => ['.feature_map/config.yml', 'config/code_ownership.yml'], 'skip_code_ownership' => false)
   end
 
   let(:create_validation_artifacts) do
@@ -168,9 +170,16 @@ RSpec.shared_context 'application fixtures' do
         app/my_error.rb:
           feature: Bar
           mapper: Annotations at the top of file
+        app/my_file.rb:
+          feature: Foo
+          mapper: Annotations at the top of file
       features:
         Bar:
+          files:
           - app/my_error.rb
+        Foo:
+          files:
+          - app/my_file.rb
     CONTENTS
     write_file('.feature_map/metrics.yml', <<~CONTENTS)
       ---


### PR DESCRIPTION
Incorporates support for generating release notifications into this gem. This will allow standardized Slack release notifications to be generated more easily across repositories.

Issue: https://linear.app/bf-settlements/issue/FEAT-94