### PR TITLE
Allow todos to be counted in any file

### DIFF
--- a/feature_map.gemspec
+++ b/feature_map.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'feature_map'
-  spec.version       = '1.2.3'
+  spec.version       = '1.2.4'
   spec.authors       = ['Beyond Finance']
   spec.email         = ['engineering@beyondfinance.com']
   spec.summary       = 'A gem to help identify and manage features within large Ruby and Rails applications'

--- a/lib/feature_map/private/feature_metrics_calculator.rb
+++ b/lib/feature_map/private/feature_metrics_calculator.rb
@@ -39,7 +39,9 @@ module FeatureMap
 
       def self.calculate_for_file(file_path)
         metrics = {
-          LINES_OF_CODE_METRIC => LinesOfCodeCalculator.new(file_path).calculate
+          LINES_OF_CODE_METRIC => LinesOfCodeCalculator.new(file_path).calculate,
+          TODO_LOCATIONS_METRIC => TodoInspector.new(file_path).calculate
+
         }
 
         return metrics unless file_path.end_with?('.rb')
@@ -55,12 +57,10 @@ module FeatureMap
         # make right now.
         abc_calculator = RuboCop::Cop::Metrics::Utils::AbcSizeCalculator.new(source.ast)
         cyclomatic_calculator = CyclomaticComplexityCalculator.new(source.ast)
-        todo_locations = TodoInspector.new(file_path).calculate
 
         metrics.merge(
           ABC_SIZE_METRIC => abc_calculator.calculate.first.round(2),
-          CYCLOMATIC_COMPLEXITY_METRIC => cyclomatic_calculator.calculate,
-          TODO_LOCATIONS_METRIC => todo_locations
+          CYCLOMATIC_COMPLEXITY_METRIC => cyclomatic_calculator.calculate
         )
       end
 

--- a/spec/lib/feature_map/private/feature_metrics_calculator_spec.rb
+++ b/spec/lib/feature_map/private/feature_metrics_calculator_spec.rb
@@ -110,8 +110,18 @@ module FeatureMap
             end
           RUBY
 
-          metrics = described_class.calculate_for_feature([file1_path, file2_path])
-          expect(metrics['todo_locations'].length).to eq(3)
+          file3_path = File.join(dir, 'file2.anything')
+          File.write(file3_path, <<~MISC)
+            # TODO: First todo
+            /* TODO: Second todo */
+            // TODO: Third todo
+            <!--
+            TODO: Fourth todo
+            -->
+          MISC
+
+          metrics = described_class.calculate_for_feature([file1_path, file2_path, file3_path])
+          expect(metrics['todo_locations'].length).to eq(7)
         end
       end
     end


### PR DESCRIPTION
We wrote todo counting to be file-type-agnostic but accidentally hid it behind a `.rb` guard.  This allows todos to be collected from anywhere with a comment style that we support.