### PR TITLE
Skip definition assignment for features without definition ymls

### DIFF
--- a/lib/feature_map/private/assignment_mappers/feature_definition_assignment.rb
+++ b/lib/feature_map/private/assignment_mappers/feature_definition_assignment.rb
@@ -13,6 +13,13 @@ module FeatureMap
           return @@map_files_to_features if @@map_files_to_features&.keys && @@map_files_to_features.keys.count.positive?
 
           @@map_files_to_features = CodeFeatures.all.each_with_object({}) do |feature, map| # rubocop:disable Style/ClassVars
+            # NOTE:  The FeatureDefinitionAssignment naively assumes that all
+            #        features will have a definition yaml file.  This comes from
+            #        the CodeOwnership implementation which does require these
+            #        files to exist.  This is not true in repositories using the
+            #        feature_definitions.csv style of feature definition.
+            next if feature.config_yml.nil?
+
             map[feature.config_yml] = feature
           end
         end
@@ -27,6 +34,13 @@ module FeatureMap
           return {} if Private.configuration.ignore_feature_definitions
 
           CodeFeatures.all.each_with_object({}) do |feature, map|
+            # NOTE:  The FeatureDefinitionAssignment naively assumes that all
+            #        features will have a definition yaml file.  This comes from
+            #        the CodeOwnership implementation which does require these
+            #        files to exist.  This is not true in repositories using the
+            #        feature_definitions.csv style of feature definition.
+            next if feature.config_yml.nil?
+
             map[feature.config_yml] = feature
           end
         end

--- a/spec/lib/feature_map/private/assignment_mappers/feature_definition_assignment_spec.rb
+++ b/spec/lib/feature_map/private/assignment_mappers/feature_definition_assignment_spec.rb
@@ -1,10 +1,14 @@
 module FeatureMap
   RSpec.describe Private::AssignmentMappers::FeatureDefinitionAssignment do
     before do
-      write_configuration
-      write_file('.feature_map/definitions/bar.yml', <<~CONTENTS)
-        name: Bar
-      CONTENTS
+      write_configuration('assigned_globs' => '**/*')
+      write_file('.feature_map/feature_definitions.csv', <<~CSV.strip)
+        Name,Description,Documentation Link,Dashboard Link,Custom Attribute
+        Bar,,,,
+      CSV
+      write_file('foo.rb', <<~FILE.strip)
+        # @feature Bar
+      FILE
     end
 
     describe 'FeatureMap.for_feature' do

--- a/spec/lib/feature_map_spec.rb
+++ b/spec/lib/feature_map_spec.rb
@@ -1,6 +1,28 @@
 RSpec.describe FeatureMap do
   # Look at individual validations spec to see other validaions that ship with FeatureMap
   describe '.validate!' do
+    describe 'when no feature definition files exist' do
+      it 'does not error' do
+        # NOTE:  The FeatureDefinitionAssignment naively assumes that all
+        #        features will have a definition yaml file.  This comes from
+        #        the CodeOwnership implementation which does require these
+        #        files to exist.  This is not true in repositories using the
+        #        feature_definitions.csv style of feature definition.
+        write_configuration('assigned_globs' => ['**/some_file.ts'])
+        write_file('.feature_map/feature_definitions.csv', <<~CSV.strip)
+          Name,Description,Documentation Link,Dashboard Link,Custom Attribute
+          Bar,,,,
+        CSV
+
+        write_file('app/services/[test]/some_file.ts', <<~TYPESCRIPT)
+          // @feature Bar
+          // Countries
+        TYPESCRIPT
+
+        expect { FeatureMap.validate! }.to_not raise_error
+      end
+    end
+
     describe 'features must exist validation' do
       before do
         write_file('.feature_map/definitions/bar.yml', <<~CONTENTS)


### PR DESCRIPTION
Resolves error when `ignore_feature_definitions` is unspecified.

![CleanShot 2025-03-10 at 13 12 05@2x](https://github.com/user-attachments/assets/00338377-eab1-4867-8f3e-1e1decb5db2c)
