### PR TITLE
Add dependabot alert for CVEs

### DIFF
--- a/.github/workflows/dependabot_slack_alerts.yml
+++ b/.github/workflows/dependabot_slack_alerts.yml
@@ -1,0 +1,17 @@
+name: 'Dependabot vulerabilities notification to Slack'
+
+on:
+  schedule:
+    - cron: '0 09 * * *' # Cron
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+jobs:
+  Notify-Vulnerabilites:
+    runs-on: ubuntu-latest
+    steps:
+      # Latest version available at: https://github.com/kunalnagarco/action-cve/releases
+      - name: Notify Vulnerabilities
+        uses: kunalnagarco/action-cve@v1.12.36
+        with:
+          token: ${{ secrets.ACCESS_TOKEN_GITHUB }} # This secret is located in settings > actions > Repository secrets
+          slack_webhook: ${{ secrets.SLACK_WEBHOOK }} # This secret is located in settings > actions > Repository secrets


### PR DESCRIPTION
Adds dependabot alert github action based on a similar workflow in glue:  https://github.com/Beyond-Finance/glue/blob/83d9d5dcc910de655c613e753a8e78d0c8429ca3/.github/workflows/dependabot_slack_alerts.yaml#L18