### PR TITLE
FEAT-254: Picomatch Upgrade

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -5121,9 +5121,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
* Upgrades picomatch to address reported security vulnerability.
* https://github.com/micromatch/picomatch/security/advisories/GHSA-3v7f-55p6-f55p

## Local Validation

<img width="940" height="1564" alt="Screenshot 2026-03-31 at 5 49 07 AM" src="https://github.com/user-attachments/assets/1109faf4-8968-4029-9467-1803d7e31159" />
